### PR TITLE
fixed weather card width issue

### DIFF
--- a/src/app/carousel/carousel.component.css
+++ b/src/app/carousel/carousel.component.css
@@ -1,0 +1,8 @@
+
+/* somehow, having this bit of CSS in here stops the carousel from breaking. */
+/* trying to put this into the global styles just breaks everything. */
+.weather-carousel {
+  width: 90%;
+  margin-left: 2.5%;
+  margin-right: 2.5%;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,7 +5,7 @@
 
 .weather-carousel {
   width: 90%;
-  margin: 2.5%;
+  height: 90%;
 }
 
 .weather-card {
@@ -13,22 +13,15 @@
   border: 1px solid black;
   position: relative;
   margin: 0.5vw;
+  height: 90%;
 }
 
 .card-narrow {
-  width: 12.5vw;
+  width: 12.3vw;
 }
 
 .card-wide {
-  width: 17vw;
-}
-
-.weather-card-wide {
-  width: 1000px;
-  margin: 0.5vw;
-  background-color: white;
-  border: 1px solid black;
-  position:relative;
+  width: 16.9vw;
 }
 
 .weather-card-city-name {
@@ -42,6 +35,8 @@
 .weather-card-city-date {
   text-align: center;
   overflow: hidden;
+  margin-top: 5px;
+  margin-bottom: 5px;
 }
 
 .weather-card-conditions-img {
@@ -55,9 +50,12 @@
 .weather-card-conditions-text {
   text-align: center;
   overflow: hidden;
+  margin-top: 5px;
+  margin-bottom: 5px;
 }
 
 .weather-card-remove-button {
+  font-size: 8pt;
   display: block;
   margin: auto;
 }
@@ -68,23 +66,27 @@
 
 .weather-card-temperature-col {
   width: 33%;
+  height: 2px;
   overflow: hidden;
 }
 
 .weather-card-temperature-min-text {
   margin: 5px;
+  font-size: 8pt;
   text-align: left;
   overflow: hidden;
 }
 
 .weather-card-temperature-avg-text {
   margin: 5px;
+  font-size: 8pt;
   text-align: center;
   overflow: hidden;
 }
 
 .weather-card-temperature-max-text {
   margin: 5px;
+  font-size: 8pt;
   text-align: right;
   overflow: hidden;
 }


### PR DESCRIPTION
it sure is weird that the carousel-width class has its width defined as 90% twice - once in styles.css and again in carousel.component.css... but removing one of them breaks the carousel.  like they say, don't fix what ain't broke...